### PR TITLE
Fixed screenshot delay to catch level up yellow animation

### DIFF
--- a/Hardcore.lua
+++ b/Hardcore.lua
@@ -47,6 +47,7 @@ local HARDCORE_REALMS = {"Bloodsail Buccaneers", "Hydraxian Waterlords"}
 local GENDER_GREETING = {"guildmate", "brother", "sister"}
 local recent_levelup = nil
 local Last_Attack_Source = nil
+local PICTURE_DELAY = .65
 
 --frame display
 local display = "Deaths"
@@ -172,7 +173,7 @@ function Hardcore:PLAYER_DEAD()
 	if Hardcore_Settings.enabled == false then return end
 
 	--screenshot
-	C_Timer.After(.35, Screenshot)
+	C_Timer.After(PICTURE_DELAY, Screenshot)
 
 	-- Get information
 	local playerId = UnitGUID("player")
@@ -260,7 +261,7 @@ function Hardcore:PLAYER_LEVEL_UP(...)
 
 	--take screenshot (got this idea from DingPics addon)
 	-- wait a bit so the yellow animation appears
-	C_Timer.After(.35, Screenshot)
+	C_Timer.After(PICTURE_DELAY, Screenshot)
 end
 
 function Hardcore:TIME_PLAYED_MSG(...)


### PR DESCRIPTION
Noticed in the comments for the function on event of **PLAYER_LEVEL_UP** that there was a ".35" delay with the goal to catch the yellow animation of the character leveling up. On reviewing my personal screenshots I noticed it was too narrow of a range and on increasing it in the source file to ".65" it worked as expected!

Example:

**Old:**
- Notice level up in chat box
- no animation
- experience bar still showing pre-level up XP
- Character information panel still showing previous level.
![WoWScrnShot_112220_185058](https://user-images.githubusercontent.com/39794309/100230262-c62c0080-2f25-11eb-8204-563c1a05dece.jpg)

**New:**
- Visible yellow level-up animation.
- Experience bar properly showing new XP.
![WoWScrnShot_112520_133938](https://user-images.githubusercontent.com/39794309/100230369-f2e01800-2f25-11eb-80d4-5516af979235.jpg)



Note: also reusing the constant variable for the **PLAYER_DEAD** screenshot. This might be undesirable?

Cheers!

Commits:
- increased SS delay + refactored SS delay value to file constant